### PR TITLE
feature: load siteIcon from GeneralSettings in GraphQL, display two d…

### DIFF
--- a/examples/nextjs/starter/src/app/layout.tsx
+++ b/examples/nextjs/starter/src/app/layout.tsx
@@ -11,9 +11,11 @@ export default function Layout( { children }: { children: React.ReactNode } ) {
 
 /**
  * Generate custom metadata with rootMetadata generated using generateRootMeraData.
+ *
+ * @return dynamic metadata generated from generateRootMetaData() and custom logic.
  */
 export async function generateMetadata(): Promise< Metadata > {
-	const rootMetaData = generateRootMetaData();
+	const rootMetaData = await generateRootMetaData();
 	return {
 		...rootMetaData,
 	};

--- a/packages/next/src/root-layout/index.tsx
+++ b/packages/next/src/root-layout/index.tsx
@@ -2,6 +2,7 @@ import React, { type PropsWithChildren } from 'react';
 import { QueryEngine } from '@snapwp/query';
 import { GlobalHead } from './global-head';
 import type { Metadata } from 'next';
+import type { GeneralSettingsProps } from '@snapwp/types';
 
 export type RootLayoutProps = {
 	getGlobalStyles?: ( typeof QueryEngine )[ 'getGlobalStyles' ];
@@ -32,27 +33,131 @@ export async function RootLayout( {
 	);
 }
 
+type IconTypes = {
+	faviconIcons: Icon[];
+	appleIcons: Icon[];
+	msApplicationTileIcon: Icon;
+};
+
+type Icon = {
+	sourceUrl: string;
+	height: string;
+	width: string;
+};
+
+type FormattedIcon = {
+	url: string;
+	sizes: string;
+};
+
 /**
- * Export our custom metadata like icons, manifest, SEO metadata etc.
- * This function can be async (https://nextjs.org/docs/app/api-reference/functions/generate-metadata#async-function) and we can also use fetch API or make a GraphQL request to fetch data from server.
+ * Fetch site icon data and filter them into categorized formats.
+ * @see - https://developer.wordpress.org/reference/functions/wp_site_icon/#:~:text=Displays%20site%20icon%20meta%20tags. Reason why we are different resolution icons into individual category.
+ *
+ * @return Categorized icons.
+ */
+const getIcons = async (): Promise< Partial< IconTypes > > => {
+	const settings: GeneralSettingsProps =
+		await QueryEngine.getGeneralSettings();
+
+	const sizes = settings?.generalSettings?.siteIcon?.mediaDetails?.sizes;
+
+	// Early return if no sizes exist
+	if ( ! sizes ) {
+		const fallbackUrl = settings?.generalSettings?.siteIcon?.mediaItemUrl;
+		return fallbackUrl
+			? {
+					faviconIcons: [
+						{ width: '512', height: '512', sourceUrl: fallbackUrl },
+					],
+			  }
+			: {};
+	}
+
+	// Filter out valid icons
+	const validIcons: Icon[] = sizes.filter(
+		( icon ) => !! ( icon?.sourceUrl && icon?.height && icon?.width )
+	) as Icon[];
+
+	return {
+		faviconIcons: filterIconsBySize( validIcons, [ '32x32', '192x192' ] ),
+		appleIcons: filterIconsBySize( validIcons, [ '180x180' ] ),
+		msApplicationTileIcon: findIconBySize( validIcons, '270x270' ),
+	};
+};
+
+/**
+ * Filter icons by multiple size formats.
+ *
+ * @param icons - List of all available icons.
+ * @param sizes - Array of sizes in "WxH" format (e.g., "32x32").
+ * @return Filtered list of icons.
+ */
+const filterIconsBySize = ( icons: Icon[], sizes: string[] ): Icon[] =>
+	icons.filter( ( icon ) =>
+		sizes.includes( `${ icon.width }x${ icon.height }` )
+	);
+
+/**
+ * Find a single icon matching the specified size.
+ *
+ * @param icons - List of icons.
+ * @param size - Size in "WxH" format (e.g., "270x270").
+ * @return The first matching icon or undefined.
+ */
+const findIconBySize = ( icons: Icon[], size: string ): Icon | undefined =>
+	icons.find( ( icon ) => `${ icon.width }x${ icon.height }` === size );
+
+/**
+ * Format icons into the required metadata structure.
+ *
+ * @param icons - List of icons.
+ *
+ * @return Formatted list of icons.
+ */
+const formatIcons = ( icons: Icon[] ): FormattedIcon[] =>
+	icons.map( ( { sourceUrl, width, height } ) => ( {
+		url: sourceUrl,
+		sizes: `${ width }x${ height }`,
+	} ) );
+
+/**
+ * Generate metadata for icons.
+ * @see https://developer.wordpress.org/reference/functions/wp_site_icon/#:~:text=Displays%20site%20icon%20meta%20tags.
+ *
+ * @param icons - Object containing faviconIcons and appleIcons.
+ * @param icons.faviconIcons - Favicon icons
+ * @param icons.appleIcons - Apple touch icons
+ *
+ * @return Metadata formatted for Next.js.
+ */
+const generateIconsMetaData = ( {
+	faviconIcons,
+	appleIcons,
+}: Omit<
+	Partial< IconTypes >,
+	'msApplicationTileIcon'
+> ): Metadata[ 'icons' ] => ( {
+	...( faviconIcons ? { icon: formatIcons( faviconIcons ) } : { icon: '#' } ),
+	...( appleIcons ? { apple: formatIcons( appleIcons ) } : {} ),
+} );
+
+/**
+ * Generate and return root metadata, including icons and other metadata.
  *
  * @return Merged metadata.
  */
-export function generateRootMetaData(): Metadata {
+export async function generateRootMetaData(): Promise< Metadata > {
+	// Fetch icons in required format, apply faviconIcons and apple touch icons in icons metadata property while apply msapplication-TileImage in other metadata property
+	const { faviconIcons, appleIcons, msApplicationTileIcon } =
+		await getIcons();
+
 	return {
-		icons: generateIconsMetaData(),
+		icons: generateIconsMetaData( { faviconIcons, appleIcons } ),
+		other: {
+			...( msApplicationTileIcon && {
+				'msapplication-TileImage': msApplicationTileIcon.sourceUrl,
+			} ),
+		},
 	};
 }
-
-/**
- * Generate Icons metadata for nextJS
- *
- * @return Icons metadata.
- */
-const generateIconsMetaData = (): Metadata[ 'icons' ] => {
-	return {
-		// This is an interim solution for the favicon.ico making a separate GraphQL request, we are setting # as icon so Browser won't make any default request to /favicon.ico path.
-		// @todo: Once the site icon field is exposed make graphQL request to get that URL and replace it with # and remove these both comments.
-		icon: '#',
-	};
-};

--- a/packages/query/src/queries/get-general-settings.graphql
+++ b/packages/query/src/queries/get-general-settings.graphql
@@ -1,0 +1,14 @@
+query GetGeneralSettings {
+	generalSettings {
+		siteIcon {
+			mediaDetails {
+				sizes {
+					width
+					height
+					sourceUrl
+				}
+			}
+			mediaItemUrl
+		}
+	}
+}

--- a/packages/query/src/query-engine/index.ts
+++ b/packages/query/src/query-engine/index.ts
@@ -1,6 +1,7 @@
 import { getGraphqlUrl, getConfig } from '@snapwp/core/config';
 import {
 	GetCurrentTemplateDocument,
+	GetGeneralSettingsDocument,
 	GetGlobalStylesDocument,
 } from '@graphqlTypes/graphql';
 import {
@@ -70,6 +71,42 @@ export class QueryEngine {
 			} );
 
 			return parseGlobalStyles( data );
+		} catch ( error ) {
+			if ( error instanceof ApolloError ) {
+				logApolloErrors( error );
+
+				// If there are networkError throw the error with proper message.
+				if ( error.networkError ) {
+					// Throw the error with proper message.
+					throw new Error(
+						getNetworkErrorMessage( error.networkError )
+					);
+				}
+			}
+
+			// If error is not an instance of ApolloError, throw the error again.
+			throw error;
+		}
+	};
+
+	/**
+	 * Fetches the general settings, like favicon icon.
+	 *
+	 * @return General settings data.
+	 */
+	static getGeneralSettings = async () => {
+		if ( ! QueryEngine.isClientInitialized ) {
+			QueryEngine.initialize();
+		}
+
+		try {
+			const data = await QueryEngine.apolloClient.query( {
+				query: GetGeneralSettingsDocument,
+				fetchPolicy: 'network-only', // @todo figure out a caching strategy, instead of always fetching from network
+				errorPolicy: 'all',
+			} );
+
+			return data.data;
 		} catch ( error ) {
 			if ( error instanceof ApolloError ) {
 				logApolloErrors( error );

--- a/packages/query/src/utils/parse-general-settings.ts
+++ b/packages/query/src/utils/parse-general-settings.ts
@@ -1,0 +1,25 @@
+import { Logger } from '@snapwp/core';
+import type { ApolloQueryResult } from '@apollo/client';
+import type { GetGeneralSettingsQuery } from '@graphqlTypes/graphql';
+import type { GeneralSettingsProps } from '@snapwp/types';
+
+/**
+ * Parses general settings data into props for rendering a template.
+ *
+ * @param queryData - The data fetched from the general settings
+ *
+ * @throws Throws an error if the query data is missing or invalid.
+ *
+ * @return An object containing parsed general settings.
+ */
+export default function parseGeneralSettingsResult(
+	queryData: ApolloQueryResult< GetGeneralSettingsQuery >
+): GeneralSettingsProps {
+	if ( queryData.errors?.length ) {
+		queryData.errors?.forEach( ( error ) => {
+			Logger.error( `Error fetching general settings: ${ error }` );
+		} );
+	}
+
+	return queryData.data;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './blocks';
+export * from './queries';

--- a/packages/types/src/queries/general-settings.ts
+++ b/packages/types/src/queries/general-settings.ts
@@ -1,0 +1,14 @@
+export interface GeneralSettingsProps {
+	generalSettings?: {
+		siteIcon?: {
+			mediaItemUrl?: string | null;
+			mediaDetails?: {
+				sizes?: Array< {
+					width?: string | null;
+					height?: string | null;
+					sourceUrl?: string | null;
+				} | null > | null;
+			} | null;
+		} | null;
+	} | null;
+}

--- a/packages/types/src/queries/index.ts
+++ b/packages/types/src/queries/index.ts
@@ -1,0 +1,1 @@
+export * from './general-settings';


### PR DESCRIPTION
…ifferent size of Icon as favicon, 180x180 res icon as apple touch icon and 270x270 as msApplicationTileImage

<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->


### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->


## Additional Info
<!-- Please include any relevant logs, error output, etc -->


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [ ] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [ ] My code is tested to the best of my abilities.
-   [ ] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
